### PR TITLE
Port to clang

### DIFF
--- a/list_test.c
+++ b/list_test.c
@@ -95,7 +95,7 @@ static uint8_t _test_sequence(test_list* list, test_id_t start, test_id_t stop)
     return 0;
 }
 
-static int _compare_pid(test_id_t existing_pid, test_id_t new_pid)
+static int _compare_pid(test_id_t existing_pid, test_id_t new_pid, void* user_data)
 {
     if (existing_pid > new_pid)
         return 1;
@@ -107,7 +107,7 @@ static int _compare_pid(test_id_t existing_pid, test_id_t new_pid)
 
 }
 
-static int _find_pid(test_id_t pid1, test_id_t pid2)
+static int _find_pid(test_id_t pid1, test_id_t pid2, void* user_data)
 {
     return pid1 == pid2;
 
@@ -224,41 +224,41 @@ void run_list_tests()
     }
 
 
-    test_list_insert_sorted(&p1, 2, _compare_pid);
+    test_list_insert_sorted(&p1, 2, _compare_pid, 0);
     if (_test_sequence(&p1, 2, 2)) {
         puts("Failed list test 4.1.\n");
         exit(255);
     }
 
-    test_list_insert_sorted(&p1, 1, _compare_pid);
+    test_list_insert_sorted(&p1, 1, _compare_pid, 0);
     if (_test_sequence(&p1, 2, 1)) {
         puts("Failed list test 4.2.\n");
         exit(255);
     }
 
-    test_list_insert_sorted(&p1, 3, _compare_pid);
+    test_list_insert_sorted(&p1, 3, _compare_pid, 0);
     if (_test_sequence(&p1, 3, 1)) {
         puts("Failed list test 4.3.\n");
         exit(255);
     }
 
-    test_list_insert_sorted(&p1, 7, _compare_pid);
-    test_list_insert_sorted(&p1, 6, _compare_pid);
-    test_list_insert_sorted(&p1, 5, _compare_pid);
+    test_list_insert_sorted(&p1, 7, _compare_pid, 0);
+    test_list_insert_sorted(&p1, 6, _compare_pid, 0);
+    test_list_insert_sorted(&p1, 5, _compare_pid, 0);
 
-    test_list_insert_sorted(&p1, 4, _compare_pid);
+    test_list_insert_sorted(&p1, 4, _compare_pid, 0);
     if (_test_sequence(&p1, 7, 1)) {
         puts("Failed list test 4.4.\n");
         exit(255);
     }
 
-    test_list_insert_sorted(&p1, 8, _compare_pid);
+    test_list_insert_sorted(&p1, 8, _compare_pid, 0);
     if (_test_sequence(&p1, 8, 1)) {
         puts("Failed list test 4.5.\n");
         exit(255);
     }
 
-    node = test_list_find_node(&p1, 1, _find_pid);
+    node = test_list_find_node(&p1, 1, _find_pid, 0);
 
     if (node->data != 1) {
         puts("Failed list test 5.1.\n");
@@ -267,13 +267,13 @@ void run_list_tests()
 
     test_list_delete(node);
 
-    node = test_list_find_node(&p1, 1, _find_pid);
+    node = test_list_find_node(&p1, 1, _find_pid, 0);
     if (node) {
         puts("Failed list test 5.2.\n");
         exit(255);
     }
 
-    node = test_list_find_node(&p1, 2, _find_pid);
+    node = test_list_find_node(&p1, 2, _find_pid, 0);
     if (node->data != 2) {
         puts("Failed list test 5.3.\n");
         exit(255);
@@ -281,13 +281,13 @@ void run_list_tests()
 
     test_list_delete(node);
 
-    node = test_list_find_node(&p1, 2, _find_pid);
+    node = test_list_find_node(&p1, 2, _find_pid, 0);
     if (node) {
         puts("Failed list test 5.4.\n");
         exit(255);
     }
 
-    node = test_list_find_node(&p1, 7, _find_pid);
+    node = test_list_find_node(&p1, 7, _find_pid, 0);
     if (node->data != 7) {
         puts("Failed list test 5.5.\n");
         exit(255);
@@ -295,7 +295,7 @@ void run_list_tests()
 
     test_list_delete(node);
 
-    node = test_list_find_node(&p1, 7, _find_pid);
+    node = test_list_find_node(&p1, 7, _find_pid, 0);
     if (node) {
         puts("Failed list test 5.6.\n");
         exit(255);

--- a/reliable_multicast.h
+++ b/reliable_multicast.h
@@ -37,13 +37,6 @@ typedef union {
 #define user_data_i32(_i32) ((user_data_t) { .i32 = _i32 })
 #define user_data_ptr(_ptr) ((user_data_t) { .ptr = _ptr })
 
-// Used for iterators etc.
-#define lambda(return_type, function_body) \
-    ({                                     \
-        return_type __fn__ function_body   \
-            __fn__;                        \
-    })
-
 
 extern usec_timestamp_t rmc_usec_monotonic_timestamp(void);
 

--- a/rmc_connection.c
+++ b/rmc_connection.c
@@ -350,9 +350,9 @@ int rmc_conn_process_accept(int listen_descriptor,
     if (c_ind == RMC_NIL_INDEX)
         return ENOMEM;
 
-    conn_vec->connections[c_ind].descriptor = accept4(listen_descriptor,
+    conn_vec->connections[c_ind].descriptor = accept(listen_descriptor,
                                                       (struct sockaddr*) &src_addr,
-                                                      &addr_len, SOCK_NONBLOCK);
+                                                      &addr_len);
 
     if (conn_vec->connections[c_ind].descriptor == -1)
         return errno;

--- a/rmc_connection.c
+++ b/rmc_connection.c
@@ -342,6 +342,7 @@ int rmc_conn_process_accept(int listen_descriptor,
     rmc_index_t c_ind = -1;
     int tr = 1;
     int sock_err = 0;
+    int desc_flags = 0;
 
     // Find a free slot.
     c_ind = _get_free_slot(conn_vec);
@@ -355,6 +356,10 @@ int rmc_conn_process_accept(int listen_descriptor,
 
     if (conn_vec->connections[c_ind].descriptor == -1)
         return errno;
+
+    // Set nonblocking mode on the socket.
+    desc_flags = fcntl(conn_vec->connections[c_ind].descriptor, F_GETFL, 0);
+    fcntl(conn_vec->connections[c_ind].descriptor, F_SETFL, desc_flags | O_NONBLOCK);
 
     RMC_LOG_INDEX_COMMENT(c_ind, "%s:%d assigned to index %d",
                           inet_ntoa(src_addr.sin_addr), ntohs(src_addr.sin_port), c_ind);

--- a/rmc_list.h
+++ b/rmc_list.h
@@ -78,29 +78,42 @@
     extern NODETYPE* LISTTYPE##_find_node(LISTTYPE* list,               \
                                           DATATYPE data,                \
                                           int (*compare_func)(DATATYPE needle, \
-                                                              DATATYPE haystack)); \
+                                                              DATATYPE haystack, \
+                                                              void* user_data), \
+                                          void* user_data);             \
                                                                         \
     extern NODETYPE* LISTTYPE##_find_node_rev(LISTTYPE* list,           \
                                           DATATYPE data,                \
                                           int (*compare_func)(DATATYPE needle, \
-                                                              DATATYPE haystack)); \
+                                                              DATATYPE haystack, \
+                                                              void* user_data), \
+                                          void* user_data);             \
+                                                                        \
     extern NODETYPE* LISTTYPE##_insert_sorted(LISTTYPE* list,           \
                                               DATATYPE new_elem,        \
                                               int (*compare_func)(DATATYPE new_elem, \
-                                                                  DATATYPE existing_elem)); \
-                                                                        \
+                                                                  DATATYPE existing_elem, \
+                                                                  void* user_data), \
+                                              void* user_data);         \
     extern NODETYPE* LISTTYPE##_insert_sorted_rev(LISTTYPE* list,       \
                                                   DATATYPE new_elem,    \
                                                   int (*compare_func)(DATATYPE new_elem, \
-                                                                  DATATYPE existing_elem)); \
+                                                                      DATATYPE existing_elem, \
+                                                                      void* user_data), \
+                                                  void* user_data);     \
                                                                         \
     extern NODETYPE* LISTTYPE##_insert_sorted_node(LISTTYPE* list,      \
                                                    NODETYPE* node,      \
                                                    int (*compare_func)(DATATYPE new_elem, \
-                                                                       DATATYPE existing_elem)); \
+                                                                       DATATYPE existing_elem, \
+                                                                       void* user_data), \
+                                                   void* user_data);    \
+                                                                        \
     extern NODETYPE* LISTTYPE##_insert_sorted_node_rev(LISTTYPE* list,  \
                                                        NODETYPE* node,  \
                                                        int (*compare_func)(DATATYPE new_elem, \
-                                                                           DATATYPE existing_elem)); \
+                                                                           DATATYPE existing_elem, \
+                                                                           void* user_data), \
+                                                       void* user_data);
 
 #endif // __RMC_LIST_H__

--- a/rmc_list_template.h
+++ b/rmc_list_template.h
@@ -306,7 +306,9 @@
     NODETYPE* LISTTYPE##_find_node(LISTTYPE* list,                      \
                                    DATATYPE data,                       \
                                    int (*compare_func)(DATATYPE needle, \
-                                                       DATATYPE haystack)) \
+                                                       DATATYPE haystack, \
+                                                       void* user_data), \
+                                   void* user_data)                     \
     {                                                                   \
         NODETYPE* node = 0;                                             \
                                                                         \
@@ -314,7 +316,7 @@
         node = LISTTYPE##_head(list);                                   \
                                                                         \
         while(node) {                                                   \
-            int res = (*compare_func)(data, node->data);                \
+            int res = (*compare_func)(data, node->data, user_data);     \
                                                                         \
             if (res == -1)                                              \
                 return 0;                                               \
@@ -328,9 +330,11 @@
     }                                                                   \
                                                                         \
     NODETYPE* LISTTYPE##_find_node_rev(LISTTYPE* list,                  \
-                                   DATATYPE data,                       \
-                                   int (*compare_func)(DATATYPE needle, \
-                                                       DATATYPE haystack)) \
+                                       DATATYPE data,                   \
+                                       int (*compare_func)(DATATYPE needle, \
+                                                           DATATYPE haystack, \
+                                                           void* user_data), \
+                                       void* user_data)                 \
     {                                                                   \
         NODETYPE* node = 0;                                             \
                                                                         \
@@ -338,7 +342,7 @@
         node = LISTTYPE##_tail(list);                                   \
                                                                         \
         while(node) {                                                   \
-            int res = (*compare_func)(data, node->data);                \
+            int res = (*compare_func)(data, node->data, user_data);     \
                                                                         \
             if (res == -1)                                              \
                 return 0;                                               \
@@ -355,7 +359,9 @@
     NODETYPE* LISTTYPE##_insert_sorted_node(LISTTYPE* list,             \
                                             NODETYPE* new_node,         \
                                             int (*compare_func)(DATATYPE new_elem, \
-                                                                DATATYPE existing_elem)) \
+                                                                DATATYPE existing_elem, \
+                                                                void* user_data), \
+                                            void* user_data)            \
     {                                                                   \
         NODETYPE* node = 0;                                             \
                                                                         \
@@ -363,7 +369,7 @@
         node = LISTTYPE##_head(list);                                   \
                                                                         \
         while(node) {                                                   \
-            if ((*compare_func)(new_node->data, node->data) >= 0) {     \
+            if ((*compare_func)(new_node->data, node->data, user_data) >= 0) {    \
                 return LISTTYPE##_insert_before_node(node, new_node);   \
             }                                                           \
             node = LISTTYPE##_next(node);                               \
@@ -375,7 +381,9 @@
     NODETYPE* LISTTYPE##_insert_sorted_node_rev(LISTTYPE* list,         \
                                                 NODETYPE* new_node,     \
                                                 int (*compare_func)(DATATYPE new_elem, \
-                                                                    DATATYPE existing_elem)) \
+                                                                    DATATYPE existing_elem, \
+                                                                    void* user_data), \
+                                                void* user_data)        \
     {                                                                   \
         NODETYPE* node = 0;                                             \
                                                                         \
@@ -383,7 +391,7 @@
         node = LISTTYPE##_tail(list);                                   \
                                                                         \
         while(node) {                                                   \
-            if ((*compare_func)(new_node->data, node->data) >= 0) {     \
+            if ((*compare_func)(new_node->data, node->data, user_data) >= 0) {    \
                 return LISTTYPE##_insert_after_node(node, new_node);   \
             }                                                           \
             node = LISTTYPE##_prev(node);                               \
@@ -396,7 +404,9 @@
     NODETYPE* LISTTYPE##_insert_sorted(LISTTYPE* list,                  \
                                        DATATYPE new_elem,               \
                                        int (*compare_func)(DATATYPE new_elem, \
-                                                           DATATYPE existing_elem)) \
+                                                           DATATYPE existing_elem, \
+                                                           void* user_data), \
+                                       void* user_data)                 \
     {                                                                   \
         NODETYPE* new_node = 0;                                         \
                                                                         \
@@ -406,13 +416,15 @@
         assert(new_node);                                               \
                                                                         \
         new_node->data = new_elem;                                      \
-        return LISTTYPE##_insert_sorted_node(list, new_node, compare_func); \
+        return LISTTYPE##_insert_sorted_node(list, new_node, compare_func, user_data); \
     }                                                                   \
                                                                         \
     NODETYPE* LISTTYPE##_insert_sorted_rev(LISTTYPE* list,              \
                                            DATATYPE new_elem,           \
                                            int (*compare_func)(DATATYPE new_elem, \
-                                                               DATATYPE existing_elem)) \
+                                                               DATATYPE existing_elem, \
+                                                               void* user_data), \
+                                           void* user_data)             \
     {                                                                   \
         NODETYPE* new_node = 0;                                         \
         assert(list);                                                   \
@@ -421,7 +433,7 @@
         assert(new_node);                                               \
                                                                         \
         new_node->data = new_elem;                                      \
-        return LISTTYPE##_insert_sorted_node_rev(list, new_node, compare_func); \
+        return LISTTYPE##_insert_sorted_node_rev(list, new_node, compare_func, user_data); \
     }                                                                   \
                                                                         \
     inline void LISTTYPE##_empty(LISTTYPE* list)                        \

--- a/rmc_pub_context.c
+++ b/rmc_pub_context.c
@@ -284,7 +284,7 @@ int rmc_pub_deactivate_context(rmc_pub_context_t* ctx)
 
     rmc_conn_get_max_index_in_use(&ctx->conn_vec, &max);
 
-    if (max != -1) {
+    if (max != RMC_NIL_INDEX) {
         for(ind = 0; ind <= max; ++ind) {
             rmc_connection_t* conn = rmc_conn_find_by_index(&ctx->conn_vec,
                                                             ind);
@@ -468,8 +468,8 @@ uint32_t rmc_pub_get_socket_count(rmc_pub_context_t* ctx)
         return 0;
 
     return rmc_pub_get_subscriber_count(ctx) +
-        (ctx->mcast_send_descriptor != -1)?1:0 +
-        (ctx->listen_descriptor != -1 )?1:0;
+        ((ctx->mcast_send_descriptor != -1)?1:0) +
+        ((ctx->listen_descriptor != -1 )?1:0);
 }
 
 int rmc_pub_throttling(rmc_pub_context_t* ctx,

--- a/rmc_pub_read.c
+++ b/rmc_pub_read.c
@@ -82,6 +82,10 @@ static int process_control_message(rmc_connection_t* conn, user_data_t user_data
     return 0;
 }
 
+static void _generic_payload_free(void* payload, payload_len_t payload_len, user_data_t user_data)
+{
+    free(payload);
+}
 
 int rmc_pub_close_connection(rmc_pub_context_t* ctx, rmc_index_t s_ind)
 {
@@ -108,12 +112,7 @@ int rmc_pub_close_connection(rmc_pub_context_t* ctx, rmc_index_t s_ind)
 
     RMC_LOG_INDEX_INFO(s_ind, "rmc_pub_close_connection() - ok");
     pub_reset_subscriber(&ctx->subscribers[s_ind],
-                         lambda(void, (void* payload, payload_len_t payload_len, user_data_t user_data) {
-                                 if (ctx->payload_free)
-                                     (*ctx->payload_free)(payload, payload_len, user_data);
-                                 else
-                                     free(payload);
-                             }));
+                         ctx->payload_free?ctx->payload_free:_generic_payload_free);
     return 0;
 }
 

--- a/rmc_pub_write.c
+++ b/rmc_pub_write.c
@@ -333,7 +333,7 @@ int rmc_pub_context_get_pending(rmc_pub_context_t* ctx,
     rmc_conn_get_max_index_in_use(&ctx->conn_vec, &max_ind);
 
     // If we have no subscribers, just return immediately
-    if (max_ind == -1)
+    if (max_ind == RMC_NIL_INDEX)
         // Return EBUSY if we have pending data to transmit
         return busy?EBUSY:0;
 

--- a/rmc_sub_context.c
+++ b/rmc_sub_context.c
@@ -365,5 +365,5 @@ uint32_t rmc_sub_get_socket_count(rmc_sub_context_t* ctx)
         return 0;
 
     return rmc_sub_get_publisher_count(ctx) +
-        (ctx->mcast_recv_descriptor != -1)?1:0;
+        ((ctx->mcast_recv_descriptor != -1)?1:0);
 }

--- a/rmc_sub_read.c
+++ b/rmc_sub_read.c
@@ -347,7 +347,10 @@ static int process_cmd_packet(rmc_connection_t* conn, user_data_t user_data)
     return 0;
 }
 
-
+static void _payload_free_generic(void* payload, payload_len_t payload_len, user_data_t user_data)
+{
+    free(payload);
+}
 
 int rmc_sub_close_connection(rmc_sub_context_t* ctx, rmc_index_t s_ind)
 {
@@ -356,12 +359,7 @@ int rmc_sub_close_connection(rmc_sub_context_t* ctx, rmc_index_t s_ind)
     rmc_conn_close_connection(&ctx->conn_vec, s_ind);
 
     sub_reset_publisher(&ctx->publishers[s_ind],
-                         lambda(void, (void* payload, payload_len_t payload_len, user_data_t user_data) {
-                                 if (ctx->payload_free)
-                                     (*ctx->payload_free)(payload, payload_len, user_data);
-                                 else
-                                     free(payload);
-                             }));
+                        ctx->payload_free?ctx->payload_free:_payload_free_generic);
     return 0;
 }
 

--- a/time.c
+++ b/time.c
@@ -13,7 +13,7 @@ usec_timestamp_t rmc_usec_monotonic_timestamp(void)
 {
     struct timespec res;
 
-    clock_gettime(CLOCK_BOOTTIME, &res);
+    clock_gettime(CLOCK_MONOTONIC, &res);
 
     return (usec_timestamp_t) res.tv_sec * 1000000 + res.tv_nsec / 1000;
 }


### PR DESCRIPTION
Removed lambda functions.
Replaced linux-specific calls and clocks with POSIX-compliant equivalents.